### PR TITLE
Fix a problem with TP support

### DIFF
--- a/Assets/theSphereScript.cs
+++ b/Assets/theSphereScript.cs
@@ -689,6 +689,7 @@ public class theSphereScript : MonoBehaviour
 				yield break;
 			}
 
+			yield return null;
 			foreach (IEnumerator routine in commandRoutines)
 				yield return routine;
 

--- a/Assets/theSphereScript.cs
+++ b/Assets/theSphereScript.cs
@@ -691,8 +691,11 @@ public class theSphereScript : MonoBehaviour
 
 			yield return null;
 			foreach (IEnumerator routine in commandRoutines)
+			{
 				yield return routine;
-
+				yield return "trycancel The chained command was not continued due to a request to cancel."
+			}
+			
 			yield break;
 		}
 


### PR DESCRIPTION
I forgot to add a `yield return null;` when running multiple commands.